### PR TITLE
Documentation correction: -g parameter

### DIFF
--- a/geofetch/geofetch.py
+++ b/geofetch/geofetch.py
@@ -120,7 +120,7 @@ def _parse_cmdl(cmdl):
 
 	parser.add_argument(
 			"-g", "--geofolder", default=safe_echo("GEODATA"),
-			help="Optional: Specify a location to store sra files [Default: $GEODATA:" + safe_echo("GEODATA") + "]")
+			help="Optional: Specify a location to store processed GEO files [Default: $GEODATA:" + safe_echo("GEODATA") + "]")
 	
 	parser.add_argument(
 			"--picard", dest="picard_path", default=safe_echo("PICARD"),


### PR DESCRIPTION
Not sure if my change is what should be there but it had the same caption as -s and seemed to be the location for processed data instead of SRA files.